### PR TITLE
feat(ipc): add monitor selection menu

### DIFF
--- a/Content.Client/Corvax/Ipc/IpcFaceMenu.cs
+++ b/Content.Client/Corvax/Ipc/IpcFaceMenu.cs
@@ -1,0 +1,51 @@
+using System;
+using Content.Shared.Corvax.Ipc;
+using Robust.Client.UserInterface.Controls;
+using Content.Client.UserInterface.Controls;
+using Robust.Client.ResourceManagement;
+using Robust.Shared.Utility;
+using Robust.Shared.Prototypes;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Client.UserInterface;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+namespace Content.Client.Corvax.Ipc;
+
+public sealed class IpcFaceMenu : FancyWindow
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IResourceCache _res = default!;
+
+    private readonly GridContainer _grid;
+    public event Action<string>? FaceSelected;
+
+    public IpcFaceMenu()
+    {
+        IoCManager.InjectDependencies(this);
+        Title = Loc.GetString("ipc-face-menu-title");
+        var scroll = new ScrollContainer();
+        _grid = new GridContainer { Columns = 6 };
+        scroll.AddChild(_grid);
+        ContentsContainer.AddChild(scroll);
+    }
+
+    public void Populate(string profileId, string selected)
+    {
+        _grid.RemoveAllChildren();
+        var profile = _prototype.Index<IpcFaceProfilePrototype>(profileId);
+        var rsi = _res.GetResource<RSIResource>(SpriteSpecifierSerializer.TextureRoot / profile.RsiPath).RSI;
+        foreach (var state in rsi)
+        {
+            var name = state.StateId.ToString() ?? string.Empty;
+            var texture = _res.GetResource<TextureResource>(SpriteSpecifierSerializer.TextureRoot / profile.RsiPath / $"{name}.png").Texture;
+            var button = new TextureButton { TextureNormal = texture };
+            var box = new BoxContainer { Orientation = BoxContainer.LayoutOrientation.Vertical };
+            box.AddChild(button);
+            box.AddChild(new Label { Text = name });
+            var sel = name;
+            button.OnPressed += _ => FaceSelected?.Invoke(sel);
+            _grid.AddChild(box);
+        }
+    }
+}

--- a/Content.Client/Corvax/Ipc/IpcFaceUserInterface.cs
+++ b/Content.Client/Corvax/Ipc/IpcFaceUserInterface.cs
@@ -1,0 +1,46 @@
+using System;
+using Content.Shared.Corvax.Ipc;
+using Robust.Client.GameObjects;
+using Content.Shared.UserInterface;
+
+namespace Content.Client.Corvax.Ipc;
+
+public sealed class IpcFaceUserInterface : BoundUserInterface
+{
+    private IpcFaceMenu? _menu;
+
+    public IpcFaceUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
+    {
+    }
+
+    protected override void Open()
+    {
+        base.Open();
+        _menu = new IpcFaceMenu();
+        _menu.OnClose += Close;
+        _menu.FaceSelected += state =>
+        {
+            SendPredictedMessage(new IpcFaceSelectMessage(state));
+            Close();
+        };
+        _menu.OpenCentered();
+    }
+
+    protected override void UpdateState(BoundUserInterfaceState? state)
+    {
+        if (state != null)
+            base.UpdateState(state);
+        if (_menu == null || state is not IpcFaceBuiState msg)
+            return;
+        _menu.Populate(msg.Profile, msg.Selected);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (!disposing)
+            return;
+        _menu?.Dispose();
+        _menu = null;
+    }
+}

--- a/Content.Client/Corvax/Ipc/IpcSystem.cs
+++ b/Content.Client/Corvax/Ipc/IpcSystem.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Corvax.Ipc;
+using Content.Shared.Humanoid;
+using Robust.Client.GameObjects;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+namespace Content.Client.Corvax.Ipc;
+
+public sealed partial class IpcSystem : EntitySystem
+{
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<IpcComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<IpcComponent, AfterAutoHandleStateEvent>(OnAfterState);
+    }
+
+    private void OnStartup(EntityUid uid, IpcComponent comp, ComponentStartup args)
+    {
+        UpdateFaceSprite(uid, comp);
+    }
+
+    private void OnAfterState(EntityUid uid, IpcComponent comp, AfterAutoHandleStateEvent args)
+    {
+        UpdateFaceSprite(uid, comp);
+    }
+
+    private void UpdateFaceSprite(EntityUid uid, IpcComponent comp)
+    {
+        if (!TryComp<SpriteComponent>(uid, out var sprite))
+            return;
+
+        if (!sprite.LayerMapTryGet(HumanoidVisualLayers.Snout, out var layer))
+            return;
+
+        var profile = _prototypeManager.Index<IpcFaceProfilePrototype>(comp.FaceProfile);
+        var rsi = new SpriteSpecifier.Rsi(SpriteSpecifierSerializer.TextureRoot / profile.RsiPath, comp.SelectedFace);
+        _sprite.LayerSetSprite(uid, layer, rsi);
+    }
+}

--- a/Content.Shared/Corvax/Ipc/IpcComponent.cs
+++ b/Content.Shared/Corvax/Ipc/IpcComponent.cs
@@ -9,6 +9,7 @@ namespace Content.Shared.Corvax.Ipc;
 /// This is used for...
 /// </summary>
 [RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
 public sealed partial class IpcComponent : Component
 {
     [DataField]
@@ -21,7 +22,19 @@ public sealed partial class IpcComponent : Component
     public EntProtoId DrainBatteryAction = "ActionDrainBattery";
 
     [DataField]
+    public EntProtoId ChangeFaceAction = "ActionIpcChangeFace";
+
+    [DataField]
     public EntityUid? ActionEntity;
+
+    [DataField]
+    public EntityUid? ChangeFaceActionEntity;
+
+    [DataField, AutoNetworkedField]
+    public string SelectedFace = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<IpcFaceProfilePrototype> FaceProfile = "DefaultIpcFaces";
 
     public bool DrainActivated;
 }
@@ -29,4 +42,8 @@ public sealed partial class IpcComponent : Component
 public sealed partial class ToggleDrainActionEvent : InstantActionEvent
 {
 
+}
+
+public sealed partial class OpenIpcFaceActionEvent : InstantActionEvent
+{
 }

--- a/Content.Shared/Corvax/Ipc/IpcFaceMenuMessages.cs
+++ b/Content.Shared/Corvax/Ipc/IpcFaceMenuMessages.cs
@@ -1,0 +1,32 @@
+using Content.Shared.UserInterface;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Corvax.Ipc;
+
+[Serializable, NetSerializable]
+public sealed class IpcFaceSelectMessage : BoundUserInterfaceMessage
+{
+    public readonly string State;
+    public IpcFaceSelectMessage(string state)
+    {
+        State = state;
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class IpcFaceBuiState : BoundUserInterfaceState
+{
+    public readonly string Profile;
+    public readonly string Selected;
+    public IpcFaceBuiState(string profile, string selected)
+    {
+        Profile = profile;
+        Selected = selected;
+    }
+}
+
+[NetSerializable, Serializable]
+public enum IpcFaceUiKey : byte
+{
+    Face
+}

--- a/Content.Shared/Corvax/Ipc/IpcFaceProfilePrototype.cs
+++ b/Content.Shared/Corvax/Ipc/IpcFaceProfilePrototype.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Corvax.Ipc;
+
+/// <summary>
+/// Prototype defining a collection of IPC face sprites.
+/// </summary>
+[Prototype("ipcFaceProfile")]
+public sealed partial class IpcFaceProfilePrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// Path to the RSI containing all IPC face states.
+    /// </summary>
+    [DataField("rsi")]
+    public string RsiPath { get; private set; } = string.Empty;
+}

--- a/Resources/Locale/en-US/corvax/ipc/ipc.ftl
+++ b/Resources/Locale/en-US/corvax/ipc/ipc.ftl
@@ -1,0 +1,3 @@
+ipc-component-ready = Ready to drain
+ipc-component-disabled = Battery charging disabled.
+ipc-face-menu-title = IPC monitor

--- a/Resources/Locale/en-US/ss14-ru/prototypes/corvax/actions/ipc.ftl
+++ b/Resources/Locale/en-US/ss14-ru/prototypes/corvax/actions/ipc.ftl
@@ -1,2 +1,4 @@
 ent-ActionDrainBattery = Drain battery
     .desc = Drain battery
+ent-ActionIpcChangeFace = Change face
+    .desc = Change the IPC monitor face

--- a/Resources/Locale/ru-RU/corvax/ipc/ipc.ftl
+++ b/Resources/Locale/ru-RU/corvax/ipc/ipc.ftl
@@ -1,2 +1,3 @@
 ipc-component-ready = Готов к разрядке
 ipc-component-disabled = Зарядка батареи отключена.
+ipc-face-menu-title = Выбор монитора

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/corvax/actions/ipc.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/corvax/actions/ipc.ftl
@@ -1,2 +1,4 @@
 ent-ActionDrainBattery = Включить заряд
     .desc = Разрядить батарею
+ent-ActionIpcChangeFace = Сменить лицо
+    .desc = Изменить монитор ИПЦ

--- a/Resources/Prototypes/Corvax/Actions/ipc.yml
+++ b/Resources/Prototypes/Corvax/Actions/ipc.yml
@@ -9,3 +9,14 @@
     itemIconStyle: NoItem
   - type: InstantAction
     event: !type:ToggleDrainActionEvent
+
+- type: entity
+  id: ActionIpcChangeFace
+  name: Change face
+  description: Change the IPC monitor face
+  components:
+  - type: Action
+    icon: { sprite: Corvax/Interface/ipcactions.rsi, state: on }
+    itemIconStyle: NoItem
+  - type: InstantAction
+    event: !type:OpenIpcFaceActionEvent

--- a/Resources/Prototypes/Corvax/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/Corvax/Entities/Mobs/Species/ipc.yml
@@ -404,6 +404,8 @@
         type: StoreBoundUserInterface
       enum.HereticLivingHeartKey.Key: # goob edit - heretics
         type: LivingHeartMenuBoundUserInterface
+      enum.IpcFaceUiKey.Face:
+        type: IpcFaceUserInterface
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Corvax/Ipc/ipc_face_profiles.yml
+++ b/Resources/Prototypes/Corvax/Ipc/ipc_face_profiles.yml
@@ -1,0 +1,3 @@
+- type: ipcFaceProfile
+  id: DefaultIpcFaces
+  rsi: Corvax/Mobs/Customization/Ipc/ips_face.rsi


### PR DESCRIPTION
## Summary
- let IPCs open a monitor selection UI to change their face
- list all available monitor states from an RSI profile
- add action, UI wiring, and translations for face selection

## Testing
- `./.dotnet/dotnet build SpaceStation14.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688e002b0c8c832c92ed1b6ee5096081