### PR TITLE
feat(corvaxNext): add pai door hacking skill

### DIFF
--- a/Content.Server/_CorvaxNext/PAI/PAIHackDoorSystem.cs
+++ b/Content.Server/_CorvaxNext/PAI/PAIHackDoorSystem.cs
@@ -1,0 +1,59 @@
+using Content.Server.Doors.Systems;
+using Content.Shared._CorvaxNext.PAI;
+using Content.Shared.DoAfter;
+using Content.Shared.Doors.Components;
+using Content.Shared.PAI;
+
+namespace Content.Server._CorvaxNext.PAI;
+
+/// <summary>
+///     Handles the PAI door hacking ability.
+/// </summary>
+public sealed class PAIHackDoorSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly DoorSystem _door = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PAIComponent, PAIHackDoorActionEvent>(OnHackDoor);
+        SubscribeLocalEvent<PAIComponent, PAIHackDoorDoAfterEvent>(OnHackDoorDoAfter);
+    }
+
+    private void OnHackDoor(Entity<PAIComponent> ent, ref PAIHackDoorActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!HasComp<DoorComponent>(args.Target))
+            return;
+
+        var doArgs = new DoAfterArgs(EntityManager, ent.Owner, args.Delay, new PAIHackDoorDoAfterEvent(), ent.Owner, target: args.Target)
+        {
+            NeedHand = false,
+            BreakOnMove = false,
+            BreakOnDamage = true,
+            DistanceThreshold = 2f
+        };
+
+        _doAfter.TryStartDoAfter(doArgs);
+        args.Handled = true;
+    }
+
+    private void OnHackDoorDoAfter(Entity<PAIComponent> ent, ref PAIHackDoorDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled || args.Args.Target == null)
+            return;
+
+        var target = args.Args.Target.Value;
+
+        if (TryComp<DoorBoltComponent>(target, out var bolt))
+            _door.SetBoltsDown((target, bolt), false, ent.Owner);
+
+        if (TryComp<DoorComponent>(target, out var door))
+            _door.StartOpening(target, door, ent.Owner);
+
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/_CorvaxNext/PAI/PAIHackDoorAction.cs
+++ b/Content.Shared/_CorvaxNext/PAI/PAIHackDoorAction.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Actions;
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CorvaxNext.PAI;
+
+/// <summary>
+///     Event raised when a PAI attempts to hack a door via action.
+///     Delay controls the hacking time before the door opens.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class PAIHackDoorActionEvent : EntityTargetActionEvent
+{
+    /// <summary>
+    ///     Hacking time in seconds.
+    /// </summary>
+    [DataField("delay")]
+    public float Delay = 3f;
+}
+
+/// <summary>
+///     Raised after the hacking delay completes.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class PAIHackDoorDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Resources/Prototypes/_CorvaxNext/Actions/pai.yml
+++ b/Resources/Prototypes/_CorvaxNext/Actions/pai.yml
@@ -1,0 +1,17 @@
+- type: entity
+  id: ActionPAIHackDoor
+  name: Door Hack
+  description: Hack a targeted door open after a short delay, even if bolted.
+  components:
+  - type: Action
+    useDelay: 60
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_ai.rsi, state: unbolt_door }
+  - type: EntityTargetAction
+    event: !type:PAIHackDoorActionEvent
+      delay: 5
+    checkCanInteract: false
+    checkCanAccess: false
+    whitelist:
+      components:
+      - DoorComponent

--- a/Resources/Prototypes/_CorvaxNext/Catalog/pai_catalog.yml
+++ b/Resources/Prototypes/_CorvaxNext/Catalog/pai_catalog.yml
@@ -1,0 +1,12 @@
+- type: listing
+  id: PAIHackDoor
+  name: Door Hack
+  description: Allows your PAI to hack and open doors.
+  productAction: ActionPAIHackDoor
+  cost:
+    SiliconMemory: 10
+  categories:
+  - PAIAbilities
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1


### PR DESCRIPTION
## Summary
- add PAI door hack ability with configurable delay
- allow PAIs to purchase and use the door hack action

## Testing
- `dotnet build Content.Server` *(fails: Sharp 3.1.7 vulnerability, restore canceled)*
- `dotnet test Content.Tests/Content.Tests.csproj` *(fails: build stopped due to logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68909bd968a0832cb87b80b466446292